### PR TITLE
Default to "now" if no argument/query is supplied

### DIFF
--- a/workflow/info.plist
+++ b/workflow/info.plist
@@ -45,13 +45,15 @@
 			<key>config</key>
 			<dict>
 				<key>argumenttype</key>
-				<integer>0</integer>
+				<integer>1</integer>
 				<key>escaping</key>
 				<integer>36</integer>
 				<key>keyword</key>
 				<string>df</string>
 				<key>script</key>
-				<string>python process.py "{query}"</string>
+				<string>QQ="{query}"
+if [ -z "$QQ" ]; then QQ="now"; fi
+python process.py "$QQ"</string>
 				<key>subtext</key>
 				<string>Examples: 1364302555, 2013-01-15 19:41:06, now</string>
 				<key>title</key>


### PR DESCRIPTION
In the workflow config, makes the argument optional and changes the bash script to default the query to "now" if no argument is provided.
