### PR TITLE
Add support for UTC inputs in milliseconds format

### DIFF
--- a/workflow/process.py
+++ b/workflow/process.py
@@ -20,6 +20,8 @@ def parse_query_value(query_str):
             d = utcnow()
         else:
             # Parse datetime string or timestamp
+            if len(query_str) == 13:
+                query_str = int(query_str)/int('1000')
             try:
                 d = epoch(float(query_str))
             except ValueError:


### PR DESCRIPTION
Because we're converting to timestamps without milliseconds, it will be rounded to date formats with nearest second (using native Python to round)